### PR TITLE
bugfixes to reduce memory usage and interpret cftime reference point

### DIFF
--- a/tools/luh2/luh2.py
+++ b/tools/luh2/luh2.py
@@ -62,7 +62,7 @@ def main():
     # This is an old requirement of the HLM and should simply be a copy of the `time` dimension
     # If we are merging, we might not need to do this, so check to see if its there already
     if (not "YEAR" in list(regrid_luh2.variables)):
-        regrid_luh2["YEAR"] = date2num(regrid_luh2.time,'common_years since 0-00-00 00:00:00')
+        regrid_luh2["YEAR"] = date2num(regrid_luh2.time,'common_years since 0-01-01 00:00:00')
         regrid_luh2["LONGXY"] = ds_regrid_target["LONGXY"] # TO DO: double check if this is strictly necessary
         regrid_luh2["LATIXY"] = ds_regrid_target["LATIXY"] # TO DO: double check if this is strictly necessary
 

--- a/tools/luh2/luh2mod.py
+++ b/tools/luh2/luh2mod.py
@@ -14,7 +14,7 @@ def ImportData(input_file,start=None,stop=None,merge_flag=False):
     # Check to see if a ValueError is raised which is likely due
     # to the LUH2 time units being undecodable by cftime module
     try:
-       datasetout = xr.open_dataset(input_file)
+       datasetout = xr.open_dataset(input_file, cache=False)
     except ValueError as err:
        print("ValueError:", err)
        errmsg = "User direction: If error is due to units being 'years since ...' " \


### PR DESCRIPTION
two bugfixes: reduce the memory usage (setting cache=false in output file) and interpret cftime reference point (month and day of 01 rather than 00)